### PR TITLE
Fix editor:newline event

### DIFF
--- a/lib/SuggestionListElement.js
+++ b/lib/SuggestionListElement.js
@@ -155,9 +155,12 @@ class SuggestionList extends React.Component {
     this._subscriptions.dispose();
   }
 
-  _confirm() {
+  _confirm(event) {
     this._items[this.state.selectedIndex].callback();
     this._close();
+    if (event) {
+      event.stopImmediatePropagation();
+    }
   }
 
   _close() {


### PR DESCRIPTION
Fixed a bug that causes a line break when confirmed by non-enter key.

[![https://gyazo.com/3f211a423910318180850bb98729bd6d](https://i.gyazo.com/3f211a423910318180850bb98729bd6d.gif)](https://gyazo.com/3f211a423910318180850bb98729bd6d)